### PR TITLE
Move Cors middleware in front of rate limiting middleware

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -16,8 +16,8 @@ func Init(conf *config.Configuration, rd *redis.Client) *echo.Echo {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 	e.Use(middleware.BodyLimit(conf.AppConfig.BodyLimit))
-	e.Use(rateLimit(&conf.Rate, rd))
 	e.Use(cors())
+	e.Use(rateLimit(&conf.Rate, rd))
 
 	e.GET("/", api.Home)
 	e.POST("/bins", api.CreateBin(&conf.AppConfig, rd))


### PR DESCRIPTION
Moved the Cors middleware in front of the rate limiting middleware to be able to return HTTP 429 response when the rate limit exceeded.

Thank you for your contribution to the Istekbin repo. 
Before submitting this PR, please make sure:

- [X] Your code builds clean without any errors or warnings.
- [X] You have added unit tests.
- [X] You have run all tests. Command: go test ./internal/api/
- [X] You have checked swagger changes.